### PR TITLE
fix: error when choosing no for experts (CMC-1375) 2/2

### DIFF
--- a/ccd-definition/CaseEventToFields/ClaimantResponse.json
+++ b/ccd-definition/CaseEventToFields/ClaimantResponse.json
@@ -126,6 +126,7 @@
     "PageID": "Experts",
     "CaseEventFieldLabel": "Experts",
     "PageShowCondition": "respondent1ClaimResponseType=\"FULL_DEFENCE\" AND applicant1ProceedWithClaim = \"Yes\"",
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/experts",
     "ShowSummaryChangeOption": "Y"
   },
   {

--- a/ccd-definition/CaseEventToFields/DefendantResponse.json
+++ b/ccd-definition/CaseEventToFields/DefendantResponse.json
@@ -159,6 +159,7 @@
     "PageID": "Experts",
     "CaseEventFieldLabel": "Experts",
     "PageShowCondition": "respondent1ClaimResponseType=\"FULL_DEFENCE\"",
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/experts",
     "ShowSummaryChangeOption": "Y"
   },
   {

--- a/ccd-definition/ComplexTypes/DQ/Experts.json
+++ b/ccd-definition/ComplexTypes/DQ/Experts.json
@@ -30,7 +30,6 @@
     "FieldTypeParameter": "Expert",
     "ElementLabel": "Expert details",
     "FieldShowCondition": "expertRequired = \"Yes\"",
-    "SecurityClassification": "Public",
-    "Min": 1
+    "SecurityClassification": "Public"
   }
 ]

--- a/e2e/api/steps.js
+++ b/e2e/api/steps.js
@@ -276,6 +276,7 @@ module.exports = {
 
     await assertError('ConfirmDetails', data[eventName].invalid.ConfirmDetails.futureDateOfBirth,
       'The date entered cannot be in the future');
+    await assertError('Experts', data[eventName].invalid.Experts.emptyDetails, 'Expert details required');
     await assertError('Hearing', data[eventName].invalid.Hearing.past,
       'The date cannot be in the past and must not be more than a year in the future');
     await assertError('Hearing', data[eventName].invalid.Hearing.moreThanYear,
@@ -299,6 +300,7 @@ module.exports = {
 
     await validateEventPages(data.CLAIMANT_RESPONSE);
 
+    await assertError('Experts', data[eventName].invalid.Experts.emptyDetails, 'Expert details required');
     await assertError('Hearing', data[eventName].invalid.Hearing.past,
       'The date cannot be in the past and must not be more than a year in the future');
     await assertError('Hearing', data[eventName].invalid.Hearing.moreThanYear,

--- a/e2e/fixtures/events/claimantResponse.js
+++ b/e2e/fixtures/events/claimantResponse.js
@@ -95,6 +95,16 @@ module.exports = {
     }
   },
   invalid: {
+    Experts: {
+      emptyDetails: {
+        applicant1DQExperts: {
+          details: [],
+          expertRequired: 'Yes',
+          expertReportsSent: 'NOT_OBTAINED',
+          jointExpertSuitable: 'Yes'
+        }
+      }
+    },
     Hearing: {
       past: {
         applicant1DQHearing: {

--- a/e2e/fixtures/events/defendantResponse.js
+++ b/e2e/fixtures/events/defendantResponse.js
@@ -134,7 +134,7 @@ module.exports = {
         respondent1DQExperts: {
           details: [],
           expertRequired: 'Yes',
-          exportReportsSent: 'NOT_OBTAINED',
+          expertReportsSent: 'NOT_OBTAINED',
           jointExpertSuitable: 'Yes'
         }
       }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1375

### Change description ###

moving PR over from old repo: https://github.com/hmcts/unspec-service/pull/732

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
