### PR TITLE
fix: CVE-2021-22112 Bump spring-security-core from 5.4.2 to 5.4.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,7 @@ allprojects {
 
       // CVE-2021-29425
       dependency group: 'commons-io', name: 'commons-io', version: '2.8.0'
+
     }
     imports {
       mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2020.0.2'
@@ -278,6 +279,9 @@ dependencies {
 
   implementation group: 'org.springframework.security', name: 'spring-security-web'
   implementation group: 'org.springframework.security', name: 'spring-security-config'
+
+  // CVE-2021-22112 - Privilege Escalation
+  implementation group: 'org.springframework.security', name: 'spring-security-core', version: '5.4.6'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-client'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-resource-server'
   implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.7'

--- a/e2e/fixtures/events/createClaim.js
+++ b/e2e/fixtures/events/createClaim.js
@@ -150,7 +150,7 @@ module.exports = {
         claimFee: {
           calculatedAmountInPence: '150000',
           code: 'FEE0209',
-          version: '3'
+          version: '1'
         },
         claimIssuedPaymentDetails:  {
           customerReference: 'Applicant reference'

--- a/e2e/fragments/litigationFriend.js
+++ b/e2e/fragments/litigationFriend.js
@@ -19,6 +19,7 @@ module.exports = {
   },
 
   async enterLitigantFriendWithDifferentAddressToLitigant(partyType, address, file) {
+    I.waitForVisible(this.fields(partyType).litigationFriendName);
     I.fillField(this.fields(partyType).litigationFriendName, 'John Smith');
 
     await within(this.fields(partyType).litigantInFriendDifferentAddress.id, () => {

--- a/e2e/fragments/litigationFriend.js
+++ b/e2e/fragments/litigationFriend.js
@@ -19,7 +19,6 @@ module.exports = {
   },
 
   async enterLitigantFriendWithDifferentAddressToLitigant(partyType, address, file) {
-    I.waitForVisible(this.fields(partyType).litigationFriendName);
     I.fillField(this.fields(partyType).litigationFriendName, 'John Smith');
 
     await within(this.fields(partyType).litigantInFriendDifferentAddress.id, () => {

--- a/e2e/fragments/party.js
+++ b/e2e/fragments/party.js
@@ -26,6 +26,7 @@ module.exports = {
       I.click(this.fields(partyType).type.options.company);
     });
 
+    I.waitForVisible(this.fields(partyType).company.name);
     I.fillField(this.fields(partyType).company.name, 'Example company');
 
     await within(this.fields(partyType).address, () => {


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
CVE-2021-22112 Bump spring-security-core from 5.4.2 to 5.4.6


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
