### PR TITLE
fix: CVE-2021-22112 Bump spring-security-core from 5.4.2 to 5.4.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -284,6 +284,9 @@ dependencies {
   implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
   implementation group: 'uk.gov.hmcts.reform', name: 'idam-client', version: '2.0.0'
 
+  // CVE-2021-22112 - Privilege Escalation
+  implementation group: 'org.springframework.security', name: 'spring-security-core', version: '5.4.6'
+
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.14.1'
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.14.1'
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
CVE-2021-22112 Bump spring-security-core from 5.4.2 to 5.4.6


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
